### PR TITLE
Fix config load issue

### DIFF
--- a/evdev_joystick_calibration/MinMaxItem.py
+++ b/evdev_joystick_calibration/MinMaxItem.py
@@ -2,11 +2,11 @@ import json
 
 
 class MinMaxItem:
-    def __init__(self, analog, minimum, maximum):
+    def __init__(self, analog, minimum, maximum, flat):
         self.minimum = int(minimum)
         self.maximum = int(maximum)
         self.analog = analog
-        self.flat = 0 # flat aka deadzone
+        self.flat = flat # flat aka deadzone
 
     def __str__(self):
         return "analog: " + self.analog + " min:" + str(self.minimum) + " max:" + str(self.maximum) + " flat:" + str(self.flat)

--- a/evdev_joystick_calibration/__main__.py
+++ b/evdev_joystick_calibration/__main__.py
@@ -58,7 +58,7 @@ def main():
             if event.type == ecodes.EV_ABS:
                 if event.code not in min_max:
                     analog_name = str(evdev.categorize(event)).partition(", ")[2]
-                    min_max[event.code] = MinMaxItem(analog_name, event.value, event.value)
+                    min_max[event.code] = MinMaxItem(analog_name, event.value, event.value, 0)
                 if min_max[event.code].minimum > event.value:
                     min_max[event.code].minimum = event.value
                 if min_max[event.code].maximum < event.value:


### PR DESCRIPTION
When running `evdev-joystick-calibration -l` we get a "too many positional arguments" error because `flat` isn't an argument but we're trying to construct `MinMaxItem` like it is, this should fix the problem.

Thanks for the handy script!